### PR TITLE
Replace docstrings with comments

### DIFF
--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -42,81 +42,63 @@ if not is_graphql(url):
 
 json_output = {}
 
-"""
-    Field Suggestions
-"""
+# Field Suggestions
 if field_suggestions(url):
     json_output['Field Suggestions'] = {}
     json_output['Field Suggestions']['severity'] = 'LOW'
     json_output['Field Suggestions']['impact'] = 'Information Leakage'
     json_output['Field Suggestions']['description'] = 'Field Suggestions are Enabled'
 
-"""
-    Introspection
-"""
+# Introspection
 if introspection(url):
     json_output['Introspection'] = {}
     json_output['Introspection']['severity'] = 'HIGH'
     json_output['Introspection']['impact'] = 'Information Leakage'
     json_output['Introspection']['description'] = 'Introspection Query Enabled'
 
-"""
-    Playground
-"""
+# Playground
 if detect_graphiql(url):
     json_output['GraphiQL Playground'] = {}
     json_output['GraphiQL Playground']['severity'] = 'LOW'
     json_output['GraphiQL Playground']['impact'] = 'Information Leakage'
     json_output['GraphiQL Playground']['description'] = 'GraphiQL Explorer Enabled'
 
-"""
-    HTTP GET method support
-"""
+# HTTP GET method support
 if get_method_support(url):
     json_output['Possible CSRF (GET)'] = {}
     json_output['Possible CSRF (GET)']['severity'] = 'LOW'
     json_output['Possible CSRF (GET)']['impact'] = 'Possible CSRF'
     json_output['Possible CSRF (GET)']['description'] = 'HTTP GET method supported (maybe CSRF)'
     
-"""
-    Alias Overloading
-"""
+# Alias Overloading
 if alias_overloading(url):
     json_output['Alias Overloading'] = {}
     json_output['Alias Overloading']['severity'] = 'HIGH'
     json_output['Alias Overloading']['impact'] = 'Denial of Service'
     json_output['Alias Overloading']['description'] = 'Alias Overloading with 100+ aliases is allowed'
 
-"""
-    Batch Queries
-"""
+# Batch Queries
 if batch_query(url):
     json_output['Batch Queries'] = {}
     json_output['Batch Queries']['severity'] = 'HIGH'
     json_output['Batch Queries']['impact'] = 'Denial of Service'
     json_output['Batch Queries']['description'] = 'Batch queries allowed with 10+ simultaneous queries)'
 
-"""
-    Field Duplication
-"""
+# Field Duplication
 if field_duplication(url):
     json_output['Field Duplication'] = {}
     json_output['Field Duplication']['severity'] = 'HIGH'
     json_output['Field Duplication']['impact'] = 'Denial of Service'
     json_output['Field Duplication']['description'] = 'Queries are allowed with 500 of the same repeated field'
 
-"""
-    Tracing mode
-"""
+# Tracing mode
 if trace_mode(url):
     json_output['Tracing Mode'] = {}
     json_output['Tracing Mode']['severity'] = 'INFORMATIONAL'
     json_output['Tracing Mode']['impact'] = 'Information Leakage'
     json_output['Tracing Mode']['description'] = 'Tracing is enabled'
 
-"""
-    Directive Overloading
-"""
+# Directive Overloading
 if directive_overloading(url):
     json_output['Directive Overloading'] = {}
     json_output['Directive Overloading']['severity'] = 'HIGH'


### PR DESCRIPTION
[PEP-257](https://peps.python.org/pep-0257/) says:

> A docstring is a string literal that occurs as the first statement in a module, function, class, or method definition. Such a docstring becomes the __doc__ special attribute of that object.

One could use it for comments but it looks weird.