### PR TITLE
Always use Accept: text/html for info_graphiql.py so that graphql "playgrounds" can actually be found by default by the tool + Modified POST based url-encoded query to actually send a url-encoded body with content-type application/x-www-form-urlencoded

### DIFF
--- a/lib/tests/info_graphiql.py
+++ b/lib/tests/info_graphiql.py
@@ -18,6 +18,9 @@ def detect_graphiql(url, proxy, headers):
   endpoints = ['graphiql', 'playground', 'console', 'graphql']
 
   parsed = urlparse(url)
+  if "Accept" in headers.keys():
+    backup_accept_header=headers["Accept"]
+  headers["Accept"]= "text/html"
 
   truepath = ""
   pathlist = parsed.path.split('/')
@@ -33,5 +36,9 @@ def detect_graphiql(url, proxy, headers):
           break
       except:
         pass
+
+  del headers["Accept"]
+  if 'backup_accept_header' in locals():
+    headers["Accept"]=backup_accept_header
 
   return res

--- a/lib/tests/info_post_based_csrf.py
+++ b/lib/tests/info_post_based_csrf.py
@@ -14,7 +14,7 @@ def post_based_csrf(url, proxies, headers):
 
   q = 'query cop {__typename}'
 
-  response = request(url, proxies=proxies, headers=headers, params={'query':q}, verb='POST')
+  response = request(url, proxies=proxies, headers=headers, data={'query': q}, verb='POST')
   res['curl_verify'] = curlify(response)
 
   try:

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -11,7 +11,11 @@ def curlify(obj):
   method = req.method
   uri = req.url
   if req.body:
-    data = req.body.decode('UTF-8')
+    try:
+      data = req.body.decode('UTF-8')
+    except:
+      reqb = bytes(req.body, 'UTF-8')
+      data = reqb.decode('UTF-8')
   else:
     data = ''
   headers = ['"{0}: {1}"'.format(k, v) for k, v in req.headers.items()]

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version details of graphql-cop."""
-VERSION = '1.8b'
+VERSION = '1.9'

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version details of graphql-cop."""
-VERSION = '1.8'
+VERSION = '1.8b'


### PR DESCRIPTION
Addressing second part of issue #16