### PR TITLE
Fix shebang to use /usr/bin/env for Python 3

### DIFF
--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -1,4 +1,4 @@
-#!/usr/env/python3
+#!/usr/bin/env python3 
 import sys
 
 from json import loads, dumps


### PR DESCRIPTION
This pull request updates the shebang in the Python script to use the more portable `#!/usr/bin/env python3` instead of `#!/usr/env python3`. 

Using `/usr/bin/env` in the shebang allows the script to find the Python 3 interpreter in the user's `$PATH`, making the script more portable across systems with different Python installations. This change ensures compatibility and consistent behavior for users running the script on various systems.
