### PR TITLE
feat: add variable proxy support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ Options:
                         json
   -f, --force           Forces a scan when GraphQL cannot be detected
   -d, --debug           Append a header with the test name for debugging
-  -x, --proxy           Sends the request through http://127.0.0.1:8080 proxy
+  -x PROXY, --proxy=PROXY
+                        HTTP(S) proxy URL in the form
+                        http://user:pass@host:port
   -v, --version         Print out the current version and exit.
 ```
 
@@ -97,10 +99,10 @@ python3 graphql-cop.py -t https://mywebsite.com/graphql -o json
   'title': 'Directive Overloading'}]
 ```
 
-Test a website using `graphql-cop` through a proxy (e.g. Burp Suite) with custom headers (e.g. Authorization):
+Test a website using `graphql-cop` through a proxy (e.g. Burp Suite listening on 127.0.0.1:8080) with custom headers (e.g. Authorization):
 
 ```
-$ python3 graphql-cop.py -t https://mywebsite.com/graphql --proxy --header '{"Authorization": "Bearer token_here"}'
+$ python3 graphql-cop.py -t https://mywebsite.com/graphql --proxy=http://127.0.0.1:8080 --header '{"Authorization": "Bearer token_here"}'
 
                 GraphQL Cop 1.2
            Security Auditor for GraphQL

--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -32,9 +32,9 @@ parser.add_option('-o', '--output', dest='format',
 parser.add_option('-f', '--force', dest='forced_scan', action='store_true',
                         help='Forces a scan when GraphQL cannot be detected', default=False)
 parser.add_option('-d', '--debug', dest='debug_mode', action='store_true',
-                        help='Append a header with the test name for debugging', default=False)                        
-parser.add_option('-x', '--proxy', dest='proxy', action='store_true', default=False,
-                        help='Sends the request through http://127.0.0.1:8080 proxy')
+                        help='Append a header with the test name for debugging', default=False)
+parser.add_option('-x', '--proxy', dest='proxy', default=None,
+                  help='HTTP(S) proxy URL in the form http://user:pass@host:port')
 parser.add_option('--version', '-v', dest='version', action='store_true', default=False,
                         help='Print out the current version and exit.')
 
@@ -50,10 +50,10 @@ if not options.url:
     parser.print_help()
     sys.exit(1)
 
-if options.proxy == True:
+if options.proxy:
     proxy = {
-        'http':  'http://127.0.0.1:8080',
-        'https': 'http://127.0.0.1:8080',
+        'http': options.proxy,
+        'https': options.proxy
     }
 else:
     proxy = {}


### PR DESCRIPTION
This PR adds support for http and http proxy strings, instead of the hardcoded string `127.0.0.1:8080`.
