### PR TITLE
Fix conflicting option string(s): -t

### DIFF
--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -37,7 +37,7 @@ parser.add_option('-x', '--proxy', dest='proxy', default=None,
                   help='HTTP(S) proxy URL in the form http://user:pass@host:port')
 parser.add_option('--version', '-v', dest='version', action='store_true', default=False,
                         help='Print out the current version and exit.')
-parser.add_option('--tor','-t', dest='tor', action='store_true', default=False,
+parser.add_option('--tor','-T', dest='tor', action='store_true', default=False,
                   help='Sends the request through the Tor network (ensure Tor is running and properly configured)')
 
 


### PR DESCRIPTION
The current main branch cause the following error:

```sh
python3.11  graphql-cop.py -h
Traceback (most recent call last):
  File "/home/kali/Downloads/graphql/graphql-cop/graphql-cop.py", line 40, in <module>
    parser.add_option('--tor','-t', dest='tor', action='store_true', default=False,
  File "/usr/lib/python3.11/optparse.py", line 1008, in add_option
    self._check_conflict(option)
  File "/usr/lib/python3.11/optparse.py", line 980, in _check_conflict
    raise OptionConflictError(
optparse.OptionConflictError: option -t/--tor: conflicting option string(s): -t
```

This is due the `target` and `tor` options using the `-t` flag.

Changing the Tor flag to `-T` fixes the issue.