### PR TITLE
Adding functionality for handling dictionaries for other paths where GraphQL might be located

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Options:
   -x PROXY, --proxy=PROXY
                         HTTP(S) proxy URL in the form
                         http://user:pass@host:port
+  -w, --wordlist       Path to a list of custom GraphQL endpoints.
   -v, --version         Print out the current version and exit.
   -T, --tor           Enable Tor proxy
 ```

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ Options:
   -x PROXY, --proxy=PROXY
                         HTTP(S) proxy URL in the form
                         http://user:pass@host:port
-  -w, --wordlist       Path to a list of custom GraphQL endpoints.
+  -w, --wordlist        Path to a list of custom GraphQL endpoints.
   -v, --version         Print out the current version and exit.
-  -T, --tor           Enable Tor proxy
+  -T, --tor             Enable Tor proxy
 ```
 
 Test a website

--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -20,7 +20,7 @@ from lib.tests.dos_circular_introspection import circular_query_introspection
 from lib.tests.info_get_based_mutation import get_based_mutation
 from lib.tests.info_post_based_csrf import post_based_csrf
 from lib.tests.info_unhandled_error import unhandled_error_detection
-from lib.utils import is_graphql, draw_art
+from lib.utils import is_graphql, draw_art, read_custom_wordlist
 
 from termcolor import colored
 
@@ -35,6 +35,7 @@ parser.add_option('-d', '--debug', dest='debug_mode', action='store_true',
                         help='Append a header with the test name for debugging', default=False)
 parser.add_option('-x', '--proxy', dest='proxy', default=None,
                   help='HTTP(S) proxy URL in the form http://user:pass@host:port')
+parser.add_option('-w', '--wordlist', dest='wordlist', default=False, help='Path to a list of custom GraphQL endpoints')
 parser.add_option('--version', '-v', dest='version', action='store_true', default=False,
                         help='Print out the current version and exit.')
 parser.add_option('--tor','-T', dest='tor', action='store_true', default=False,
@@ -82,7 +83,12 @@ if not urlparse(options.url).scheme:
 else:
     url = options.url
 
-endpoints = ['/graphiql', '/playground', '/console', '/graphql']
+if options.wordlist:
+    endpoints = read_custom_wordlist(options.wordlist)
+    print(endpoints)
+else:
+    endpoints = ['/graphiql', '/playground', '/console', '/graphql']
+
 paths = []
 parsed = urlparse(url)
 

--- a/graphql-cop.py
+++ b/graphql-cop.py
@@ -85,7 +85,6 @@ else:
 
 if options.wordlist:
     endpoints = read_custom_wordlist(options.wordlist)
-    print(endpoints)
 else:
     endpoints = ['/graphiql', '/playground', '/console', '/graphql']
 

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -1,4 +1,6 @@
 """Helper parts for graphql-cop."""
+import os
+
 import requests
 from simplejson import JSONDecodeError
 from version import VERSION
@@ -107,3 +109,17 @@ def draw_art():
            Security Auditor for GraphQL
              Dolev Farhi & Nick Aleks
   '''.format(version=VERSION)
+
+
+def read_custom_wordlist(location):
+  wordlists = set()
+  if os.path.exists(location):
+    f = open(location, 'r').read()
+    for line in f.splitlines():
+      if not line.startswith('/'):
+        line = '/' + line
+
+      wordlists.add(line)
+  else:
+    print('Could not find wordlist file: {}'.format(location))
+  return wordlists

--- a/version.py
+++ b/version.py
@@ -1,2 +1,2 @@
 """Version details of graphql-cop."""
-VERSION = '1.13'
+VERSION = '1.14'


### PR DESCRIPTION
Hi, great tool that was really useful during my tests. I just had to slightly modify the code because, in my case, GraphQL was located under a different endpoint. That's why I decided to add this functionality :)